### PR TITLE
Revert "prctl: adds PR_SET_TIMERSLACK_PID for setting timer slack of an ...

### DIFF
--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1845,7 +1845,6 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
 			if (current->pid != (pid_t)arg3 &&
 					!capable(CAP_SYS_NICE))
 				return -EPERM;
- PR_SET_TIMERSLACK_PID.
 			rcu_read_lock();
 			tsk = find_task_by_pid_ns((pid_t)arg3, &init_pid_ns);
 			if (tsk == NULL) {


### PR DESCRIPTION
...arbitrary thread."

This reverts commit 46b29a623f1c6780b8dcdd77d38da81d65662207.

Conflicts:
    kernel/sys.c
